### PR TITLE
Refactor to async/await

### DIFF
--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -235,8 +235,7 @@ avrgirlStk500v2.prototype.writeMemAsync = async function (memType, hex) {
 
 avrgirlStk500v2.prototype.writeMem = callbackify(avrgirlStk500v2.prototype.writeMemAsync);
 
-avrgirlStk500v2.prototype.enterProgrammingMode = function (callback) {
-  var self = this;
+avrgirlStk500v2.prototype.enterProgrammingModeAsync = async function () {
   var options = this.options.chip;
   var enable = options.pgmEnable;
 
@@ -250,30 +249,32 @@ avrgirlStk500v2.prototype.enterProgrammingMode = function (callback) {
     enable[2], enable[3]
   ]);
 
-  this.sendCmd(cmd, function (error) {
-    //var error = error ? new Error('Failed to enter prog mode: programmer return status was not OK.') : null;
-    var error = error ? new Error(error) : null;
-    callback(error);
-  });
+  try {
+    await this.sendCmdAsync(cmd);
+  } catch (error) {
+    //var error = new Error('Failed to enter prog mode: programmer return status was not OK.');
+    var error = new Error(error);
+    throw error;
+  }
 };
 
-avrgirlStk500v2.prototype.enterProgrammingModeAsync = promisify(avrgirlStk500v2.prototype.enterProgrammingMode);
+avrgirlStk500v2.prototype.enterProgrammingMode = callbackify(avrgirlStk500v2.prototype.enterProgrammingModeAsync);
 
-avrgirlStk500v2.prototype.exitProgrammingMode = function (callback) {
-  var self = this;
+avrgirlStk500v2.prototype.exitProgrammingModeAsync = async function () {
   var options = this.options.chip;
 
   var cmd = Buffer.from([
     C.CMD_LEAVE_PROGMODE_ISP, options.preDelay, options.postDelay
   ]);
 
-  this.sendCmd(cmd, function (error) {
-    var error = error ? new Error('Failed to leave prog mode: programmer return status was not OK.') : null;
-    callback(error);
-  });
+  try {
+    await this.sendCmdAsync(cmd);
+  } catch (error) {
+    throw new Error('Failed to leave prog mode: programmer return status was not OK.');
+  }
 };
 
-avrgirlStk500v2.prototype.exitProgrammingModeAsync = promisify(avrgirlStk500v2.prototype.exitProgrammingMode);
+avrgirlStk500v2.prototype.exitProgrammingMode = callbackify(avrgirlStk500v2.prototype.exitProgrammingModeAsync);
 
 avrgirlStk500v2.prototype.eraseChip = function (callback) {
   var self = this;

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -468,19 +468,20 @@ avrgirlStk500v2.prototype.writeFuseAsync = async function (fuseType, value) {
 
 avrgirlStk500v2.prototype.writeFuse = callbackify(avrgirlStk500v2.prototype.writeFuseAsync);
 
-avrgirlStk500v2.prototype.setParameter = function (param, value, callback) {
+avrgirlStk500v2.prototype.setParameterAsync = async function (param, value) {
   var cmd = Buffer.from([
     C.CMD_SET_PARAMETER,
     param, value
   ]);
 
-  this.sendCmd(cmd, function (error) {
-    var error = error ? new Error('Failed to set parameter: programmer return status was not OK.') : null;
-    callback(error);
-  });
+  try {
+    await this.sendCmdAsync(cmd);
+  } catch {
+    throw new Error('Failed to set parameter: programmer return status was not OK.');
+  }
 };
 
-avrgirlStk500v2.prototype.setParameterAsync = promisify(avrgirlStk500v2.prototype.setParameter);
+avrgirlStk500v2.prototype.setParameter = callbackify(avrgirlStk500v2.prototype.setParameterAsync);
 
 avrgirlStk500v2.prototype.getParameter = function (param, callback) {
   var self = this;

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -194,6 +194,7 @@ avrgirlStk500v2.prototype.writeMemAsync = async function (memType, hex) {
   var pageSize = options[memType].pageSize;
   var addressOffset = options[memType].addressOffset;
   var data;
+  var readFile;
 
   if (typeof hex === 'string') {
     try {

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -446,8 +446,7 @@ avrgirlStk500v2.prototype.readFuseAsync = async function (fuseType) {
 
 avrgirlStk500v2.prototype.readFuse = callbackify(avrgirlStk500v2.prototype.readFuseAsync);
 
-avrgirlStk500v2.prototype.writeFuse = function (fuseType, value, callback) {
-  var self = this;
+avrgirlStk500v2.prototype.writeFuseAsync = async function (fuseType, value) {
   var options = this.options.chip;
   var frameless = this.options.frameless;
   var readLen = frameless ? 3 : 9;
@@ -460,18 +459,14 @@ avrgirlStk500v2.prototype.writeFuse = function (fuseType, value, callback) {
     fuseCmd[2], value
   ]);
 
-  this.write(cmd, function (error) {
-    if (error) { callback(error); }
-    self.read(readLen, function (error, data) {
-      if (data[statusPos] !== C.STATUS_CMD_OK) {
-        error = new Error('Failed to program fuse: programmer return status was not OK.');
-      }
-      callback(null);
-    });
-  });
+  await this.writeAsync(cmd);
+  var data = await this.readAsync(readLen);
+  if (data[statusPos] !== C.STATUS_CMD_OK) {
+    throw new Error('Failed to program fuse: programmer return status was not OK.');
+  }
 };
 
-avrgirlStk500v2.prototype.writeFuseAsync = promisify(avrgirlStk500v2.prototype.writeFuse);
+avrgirlStk500v2.prototype.writeFuse = callbackify(avrgirlStk500v2.prototype.writeFuseAsync);
 
 avrgirlStk500v2.prototype.setParameter = function (param, value, callback) {
   var cmd = Buffer.from([

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -310,33 +310,21 @@ avrgirlStk500v2.prototype.writeEepromAsync = async function (hex) {
 
 avrgirlStk500v2.prototype.writeEeprom = callbackify(avrgirlStk500v2.prototype.writeEepromAsync);
 
-avrgirlStk500v2.prototype.quickFlash = function (hex, callback) {
-  var self = this;
-  async.series([
-    self.enterProgrammingMode.bind(self),
-    self.writeFlash.bind(self, hex),
-    self.exitProgrammingMode.bind(self)
-    ], function (error) {
-      return callback(error);
-    }
-  );
+avrgirlStk500v2.prototype.quickFlashAsync = async function (hex) {
+  await this.enterProgrammingModeAsync();
+  await this.writeFlashAsync(hex);
+  await this.exitProgrammingModeAsync();
 };
 
-avrgirlStk500v2.prototype.quickFlashAsync = promisify(avrgirlStk500v2.prototype.quickFlash);
+avrgirlStk500v2.prototype.quickFlash = callbackify(avrgirlStk500v2.prototype.quickFlashAsync);
 
-avrgirlStk500v2.prototype.quickEeprom = function (hex, callback) {
-  var self = this;
-  async.series([
-    self.enterProgrammingMode.bind(self),
-    self.writeEeprom.bind(self, hex),
-    self.exitProgrammingMode.bind(self)
-    ], function (error) {
-      return callback(error);
-    }
-  );
+avrgirlStk500v2.prototype.quickEepromAsync = async function (hex, callback) {
+  await this.enterProgrammingModeAsync();
+  await this.writeEepromAsync(hex);
+  await this.exitProgrammingModeAsync();
 };
 
-avrgirlStk500v2.prototype.quickEepromAsync = promisify(avrgirlStk500v2.prototype.quickEeprom);
+avrgirlStk500v2.prototype.quickEeprom = callbackify(avrgirlStk500v2.prototype.quickEepromAsync);
 
 avrgirlStk500v2.prototype.readFlash = function (length, callback) {
   // optional convenience method

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -2,7 +2,6 @@ var C = require('./lib/c');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var fs = require('fs');
-var async = require('async');
 var libusb = require('./lib/libusb-comms');
 var serialcom = require('./lib/serialport-comms');
 var intelhex = require('intel-hex');

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -136,15 +136,13 @@ avrgirlStk500v2.prototype.getSignatureAsync = async function () {
 
 avrgirlStk500v2.prototype.getSignature = callbackify(avrgirlStk500v2.prototype.getSignatureAsync);
 
-avrgirlStk500v2.prototype.verifySignature = function (sig, data, callback) {
-  var error = null;
+avrgirlStk500v2.prototype.verifySignatureAsync = async function (sig, data) {
   if (!sig.equals(data)) {
-    error = new Error('Failed to verify: signature does not match.');
+    throw new Error('Failed to verify: signature does not match.');
   }
-  callback(error);
 };
 
-avrgirlStk500v2.prototype.verifySignatureAsync = promisify(avrgirlStk500v2.prototype.verifySignature);
+avrgirlStk500v2.prototype.verifySignature = callbackify(avrgirlStk500v2.prototype.verifySignatureAsync);
 
 avrgirlStk500v2.prototype.loadAddress = function (memType, address, callback) {
   var dMSB = memType === 'flash' ? 0x80 : 0x00;

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -296,23 +296,19 @@ avrgirlStk500v2.prototype.eraseChipAsync = async function () {
 
 avrgirlStk500v2.prototype.eraseChip = callbackify(avrgirlStk500v2.prototype.eraseChipAsync);
 
-avrgirlStk500v2.prototype.writeFlash = function (hex, callback) {
+avrgirlStk500v2.prototype.writeFlashAsync = async function (hex) {
   // optional convenience method
-  this.writeMem('flash', hex, function(error) {
-    return callback(error);
-  });
+  await this.writeMemAsync('flash', hex);
 };
 
-avrgirlStk500v2.prototype.writeFlashAsync = promisify(avrgirlStk500v2.prototype.writeFlash);
+avrgirlStk500v2.prototype.writeFlash = callbackify(avrgirlStk500v2.prototype.writeFlashAsync);
 
-avrgirlStk500v2.prototype.writeEeprom = function (hex, callback) {
- // optional convenience method
- this.writeMem('eeprom', hex, function(error) {
-    callback(error);
-  });
+avrgirlStk500v2.prototype.writeEepromAsync = async function (hex) {
+  // optional convenience method
+  await this.writeMemAsync('eeprom', hex);
 };
 
-avrgirlStk500v2.prototype.writeEepromAsync = promisify(avrgirlStk500v2.prototype.writeEeprom);
+avrgirlStk500v2.prototype.writeEeprom = callbackify(avrgirlStk500v2.prototype.writeEepromAsync);
 
 avrgirlStk500v2.prototype.quickFlash = function (hex, callback) {
   var self = this;

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -144,7 +144,7 @@ avrgirlStk500v2.prototype.verifySignatureAsync = async function (sig, data) {
 
 avrgirlStk500v2.prototype.verifySignature = callbackify(avrgirlStk500v2.prototype.verifySignatureAsync);
 
-avrgirlStk500v2.prototype.loadAddress = function (memType, address, callback) {
+avrgirlStk500v2.prototype.loadAddressAsync = async function (memType, address) {
   var dMSB = memType === 'flash' ? 0x80 : 0x00;
   var msb = (address >> 24) & 0xFF | dMSB;
   var xsb = (address >> 16) & 0xFF;
@@ -153,13 +153,14 @@ avrgirlStk500v2.prototype.loadAddress = function (memType, address, callback) {
 
   var cmd = Buffer.from([C.CMD_LOAD_ADDRESS, msb, xsb, ysb, lsb]);
 
-  this.sendCmd(cmd, function (error) {
-    var error = error ? new Error('Failed to load address: return status was not OK.') : null;
-    callback(error);
-  });
+  try {
+    await this.sendCmdAsync(cmd);
+  } catch (error) {
+    throw new Error('Failed to load address: return status was not OK.');
+  }
 };
 
-avrgirlStk500v2.prototype.loadAddressAsync = promisify(avrgirlStk500v2.prototype.loadAddress);
+avrgirlStk500v2.prototype.loadAddress = callbackify(avrgirlStk500v2.prototype.loadAddressAsync);
 
 avrgirlStk500v2.prototype.loadPage = function (memType, data, callback) {
   if (!Buffer.isBuffer(data)) {

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -276,8 +276,7 @@ avrgirlStk500v2.prototype.exitProgrammingModeAsync = async function () {
 
 avrgirlStk500v2.prototype.exitProgrammingMode = callbackify(avrgirlStk500v2.prototype.exitProgrammingModeAsync);
 
-avrgirlStk500v2.prototype.eraseChip = function (callback) {
-  var self = this;
+avrgirlStk500v2.prototype.eraseChipAsync = async function () {
   var options = this.options.chip;
   var erase = options.erase;
 
@@ -288,13 +287,14 @@ avrgirlStk500v2.prototype.eraseChip = function (callback) {
     erase.cmd[2], erase.cmd[3]
   ]);
 
-  this.sendCmd(cmd, function (error) {
-    var error = error ? new Error('Failed to erase chip: programmer return status was not OK.') : null;
-    callback(error);
-  });
+  try {
+    await this.sendCmdAsync(cmd);
+  } catch {
+    throw new Error('Failed to erase chip: programmer return status was not OK.');
+  }
 };
 
-avrgirlStk500v2.prototype.eraseChipAsync = promisify(avrgirlStk500v2.prototype.eraseChip);
+avrgirlStk500v2.prototype.eraseChip = callbackify(avrgirlStk500v2.prototype.eraseChipAsync);
 
 avrgirlStk500v2.prototype.writeFlash = function (hex, callback) {
   // optional convenience method

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -6,6 +6,7 @@ var async = require('async');
 var libusb = require('./lib/libusb-comms');
 var serialcom = require('./lib/serialport-comms');
 var intelhex = require('intel-hex');
+const { promisify } = require('util');
 
 function avrgirlStk500v2(options) {
   this.options = {
@@ -91,6 +92,8 @@ avrgirlStk500v2.prototype.write = function (buffer, callback) {
   });
 };
 
+avrgirlStk500v2.prototype.writeAsync = promisify(avrgirlStk500v2.prototype.write);
+
 avrgirlStk500v2.prototype.read = function (length, callback) {
   var self = this;
   if (typeof length !== 'number') { return callback(new Error('Failed to read: length must be a number.')) }
@@ -101,6 +104,8 @@ avrgirlStk500v2.prototype.read = function (length, callback) {
     callback(error, buffer);
   });
 };
+
+avrgirlStk500v2.prototype.readAsync = promisify(avrgirlStk500v2.prototype.read);
 
 avrgirlStk500v2.prototype.sendCmd = function(cmd, callback) {
   var self = this;
@@ -118,6 +123,8 @@ avrgirlStk500v2.prototype.sendCmd = function(cmd, callback) {
     });
   });
 };
+
+avrgirlStk500v2.prototype.sendCmdAsync = promisify(avrgirlStk500v2.prototype.sendCmd);
 
 avrgirlStk500v2.prototype.getSignature = function (callback) {
   var self = this;
@@ -140,6 +147,8 @@ avrgirlStk500v2.prototype.getSignature = function (callback) {
   });
 };
 
+avrgirlStk500v2.prototype.getSignatureAsync = promisify(avrgirlStk500v2.prototype.getSignature);
+
 avrgirlStk500v2.prototype.verifySignature = function (sig, data, callback) {
   var error = null;
   if (!sig.equals(data)) {
@@ -147,6 +156,8 @@ avrgirlStk500v2.prototype.verifySignature = function (sig, data, callback) {
   }
   callback(error);
 };
+
+avrgirlStk500v2.prototype.verifySignatureAsync = promisify(avrgirlStk500v2.prototype.verifySignature);
 
 avrgirlStk500v2.prototype.loadAddress = function (memType, address, callback) {
   var dMSB = memType === 'flash' ? 0x80 : 0x00;
@@ -162,6 +173,8 @@ avrgirlStk500v2.prototype.loadAddress = function (memType, address, callback) {
     callback(error);
   });
 };
+
+avrgirlStk500v2.prototype.loadAddressAsync = promisify(avrgirlStk500v2.prototype.loadAddress);
 
 avrgirlStk500v2.prototype.loadPage = function (memType, data, callback) {
   if (!Buffer.isBuffer(data)) {
@@ -187,6 +200,8 @@ avrgirlStk500v2.prototype.loadPage = function (memType, data, callback) {
     return callback(error);
   });
 };
+
+avrgirlStk500v2.prototype.loadPageAsync = promisify(avrgirlStk500v2.prototype.loadPage);
 
 avrgirlStk500v2.prototype.writeMem = function (memType, hex, callback) {
   var self = this;
@@ -247,6 +262,8 @@ avrgirlStk500v2.prototype.writeMem = function (memType, hex, callback) {
   );
 };
 
+avrgirlStk500v2.prototype.writeMemAsync = promisify(avrgirlStk500v2.prototype.writeMem);
+
 avrgirlStk500v2.prototype.enterProgrammingMode = function (callback) {
   var self = this;
   var options = this.options.chip;
@@ -269,6 +286,8 @@ avrgirlStk500v2.prototype.enterProgrammingMode = function (callback) {
   });
 };
 
+avrgirlStk500v2.prototype.enterProgrammingModeAsync = promisify(avrgirlStk500v2.prototype.enterProgrammingMode);
+
 avrgirlStk500v2.prototype.exitProgrammingMode = function (callback) {
   var self = this;
   var options = this.options.chip;
@@ -282,6 +301,8 @@ avrgirlStk500v2.prototype.exitProgrammingMode = function (callback) {
     callback(error);
   });
 };
+
+avrgirlStk500v2.prototype.exitProgrammingModeAsync = promisify(avrgirlStk500v2.prototype.exitProgrammingMode);
 
 avrgirlStk500v2.prototype.eraseChip = function (callback) {
   var self = this;
@@ -301,6 +322,8 @@ avrgirlStk500v2.prototype.eraseChip = function (callback) {
   });
 };
 
+avrgirlStk500v2.prototype.eraseChipAsync = promisify(avrgirlStk500v2.prototype.eraseChip);
+
 avrgirlStk500v2.prototype.writeFlash = function (hex, callback) {
   // optional convenience method
   this.writeMem('flash', hex, function(error) {
@@ -308,12 +331,16 @@ avrgirlStk500v2.prototype.writeFlash = function (hex, callback) {
   });
 };
 
+avrgirlStk500v2.prototype.writeFlashAsync = promisify(avrgirlStk500v2.prototype.writeFlash);
+
 avrgirlStk500v2.prototype.writeEeprom = function (hex, callback) {
  // optional convenience method
  this.writeMem('eeprom', hex, function(error) {
     callback(error);
   });
 };
+
+avrgirlStk500v2.prototype.writeEepromAsync = promisify(avrgirlStk500v2.prototype.writeEeprom);
 
 avrgirlStk500v2.prototype.quickFlash = function (hex, callback) {
   var self = this;
@@ -327,6 +354,8 @@ avrgirlStk500v2.prototype.quickFlash = function (hex, callback) {
   );
 };
 
+avrgirlStk500v2.prototype.quickFlashAsync = promisify(avrgirlStk500v2.prototype.quickFlash);
+
 avrgirlStk500v2.prototype.quickEeprom = function (hex, callback) {
   var self = this;
   async.series([
@@ -339,6 +368,8 @@ avrgirlStk500v2.prototype.quickEeprom = function (hex, callback) {
   );
 };
 
+avrgirlStk500v2.prototype.quickEepromAsync = promisify(avrgirlStk500v2.prototype.quickEeprom);
+
 avrgirlStk500v2.prototype.readFlash = function (length, callback) {
   // optional convenience method
   this.readMem('flash', length, function(error, data) {
@@ -346,12 +377,16 @@ avrgirlStk500v2.prototype.readFlash = function (length, callback) {
   });
 };
 
+avrgirlStk500v2.prototype.readFlashAsync = promisify(avrgirlStk500v2.prototype.readFlash);
+
 avrgirlStk500v2.prototype.readEeprom = function (length, callback) {
  // optional convenience method
  this.readMem('eeprom', length, function(error, data) {
     callback(error, data);
   });
 };
+
+avrgirlStk500v2.prototype.readEepromAsync = promisify(avrgirlStk500v2.prototype.readEeprom);
 
 avrgirlStk500v2.prototype.readMem = function (memType, length, callback) {
   var self = this;
@@ -373,6 +408,8 @@ avrgirlStk500v2.prototype.readMem = function (memType, length, callback) {
     });
   });
 };
+
+avrgirlStk500v2.prototype.readMemAsync = promisify(avrgirlStk500v2.prototype.readMem);
 
 avrgirlStk500v2.prototype.getChipSignature = function (callback) {
   var self = this;
@@ -415,6 +452,8 @@ avrgirlStk500v2.prototype.getChipSignature = function (callback) {
 
 };
 
+avrgirlStk500v2.prototype.getChipSignatureAsync = promisify(avrgirlStk500v2.prototype.getChipSignature);
+
 avrgirlStk500v2.prototype.cmdSpiMulti = function (options, callback) {
   // // P02
   //options are [cmd, numTx, numRx, rxStartAddr, txData]
@@ -438,6 +477,8 @@ avrgirlStk500v2.prototype.readFuses = function (callback) {
     callback(null, response);
   });
 };
+
+avrgirlStk500v2.prototype.readFusesAsync = promisify(avrgirlStk500v2.prototype.readFuses);
 
 avrgirlStk500v2.prototype.readFuse = function (fuseType, callback) {
   if ((typeof fuseType).toLowerCase() !== 'string') {
@@ -467,6 +508,8 @@ avrgirlStk500v2.prototype.readFuse = function (fuseType, callback) {
   });
 };
 
+avrgirlStk500v2.prototype.readFuseAsync = promisify(avrgirlStk500v2.prototype.readFuse);
+
 avrgirlStk500v2.prototype.writeFuse = function (fuseType, value, callback) {
   var self = this;
   var options = this.options.chip;
@@ -492,6 +535,8 @@ avrgirlStk500v2.prototype.writeFuse = function (fuseType, value, callback) {
   });
 };
 
+avrgirlStk500v2.prototype.writeFuseAsync = promisify(avrgirlStk500v2.prototype.writeFuse);
+
 avrgirlStk500v2.prototype.setParameter = function (param, value, callback) {
   var cmd = Buffer.from([
     C.CMD_SET_PARAMETER,
@@ -503,6 +548,8 @@ avrgirlStk500v2.prototype.setParameter = function (param, value, callback) {
     callback(error);
   });
 };
+
+avrgirlStk500v2.prototype.setParameterAsync = promisify(avrgirlStk500v2.prototype.setParameter);
 
 avrgirlStk500v2.prototype.getParameter = function (param, callback) {
   var self = this;
@@ -520,5 +567,7 @@ avrgirlStk500v2.prototype.getParameter = function (param, callback) {
     });
   });
 };
+
+avrgirlStk500v2.prototype.getParameterAsync = promisify(avrgirlStk500v2.prototype.getParameter);
 
 module.exports = avrgirlStk500v2;

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -326,23 +326,21 @@ avrgirlStk500v2.prototype.quickEepromAsync = async function (hex, callback) {
 
 avrgirlStk500v2.prototype.quickEeprom = callbackify(avrgirlStk500v2.prototype.quickEepromAsync);
 
-avrgirlStk500v2.prototype.readFlash = function (length, callback) {
+avrgirlStk500v2.prototype.readFlashAsync = async function (length) {
   // optional convenience method
-  this.readMem('flash', length, function(error, data) {
-    callback(error, data);
-  });
+  var data = await this.readMemAsync('flash', length);
+  return data;
 };
 
-avrgirlStk500v2.prototype.readFlashAsync = promisify(avrgirlStk500v2.prototype.readFlash);
+avrgirlStk500v2.prototype.readFlash = callbackify(avrgirlStk500v2.prototype.readFlashAsync);
 
-avrgirlStk500v2.prototype.readEeprom = function (length, callback) {
- // optional convenience method
- this.readMem('eeprom', length, function(error, data) {
-    callback(error, data);
-  });
+avrgirlStk500v2.prototype.readEepromAsync = async function (length, callback) {
+  // optional convenience method
+  var data = await this.readMemAsync('eeprom', length);
+  return data;
 };
 
-avrgirlStk500v2.prototype.readEepromAsync = promisify(avrgirlStk500v2.prototype.readEeprom);
+avrgirlStk500v2.prototype.readEeprom = callbackify(avrgirlStk500v2.prototype.readEepromAsync);
 
 avrgirlStk500v2.prototype.readMem = function (memType, length, callback) {
   var self = this;

--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -162,9 +162,9 @@ avrgirlStk500v2.prototype.loadAddressAsync = async function (memType, address) {
 
 avrgirlStk500v2.prototype.loadAddress = callbackify(avrgirlStk500v2.prototype.loadAddressAsync);
 
-avrgirlStk500v2.prototype.loadPage = function (memType, data, callback) {
+avrgirlStk500v2.prototype.loadPageAsync = async function (memType, data) {
   if (!Buffer.isBuffer(data)) {
-    return callback(new Error('Failed to write page: data was not Buffer'));
+    throw new Error('Failed to write page: data was not Buffer');
   }
 
   var lMSB = data.length >> 8;
@@ -182,12 +182,10 @@ avrgirlStk500v2.prototype.loadPage = function (memType, data, callback) {
 
   cmd = Buffer.concat([cmd, data]);
 
-  this.sendCmd(cmd, function (error) {
-    return callback(error);
-  });
+  await this.sendCmdAsync(cmd);
 };
 
-avrgirlStk500v2.prototype.loadPageAsync = promisify(avrgirlStk500v2.prototype.loadPage);
+avrgirlStk500v2.prototype.loadPage = callbackify(avrgirlStk500v2.prototype.loadPageAsync);
 
 avrgirlStk500v2.prototype.writeMem = function (memType, hex, callback) {
   var self = this;

--- a/lib/libusb-comms.js
+++ b/lib/libusb-comms.js
@@ -1,3 +1,5 @@
+const { promisify } = require('util');
+
 function libusb (device) {
   this.device = device;
   this.conn = {};
@@ -43,16 +45,22 @@ libusb.prototype.setUpInterface = function (callback) {
   callback(null);
 };
 
+libusb.prototype.setUpInterfaceAsync = promisify(libusb.prototype.setUpInterface);
+
 libusb.prototype.write = function (buffer, callback) {
   this.conn.endpointOut.transfer(buffer, function (error) {
     callback(error);
   });
-}
+};
+
+libusb.prototype.writeAsync = promisify(libusb.prototype.write);
 
 libusb.prototype.read = function (length, callback) {
   this.conn.endpointIn.transfer(length, function (error, data) {
     callback(error, data);
   });
-}
+};
+
+libusb.prototype.readAsync = promisify(libusb.prototype.read);
 
 module.exports = libusb;

--- a/lib/libusb-comms.js
+++ b/lib/libusb-comms.js
@@ -1,4 +1,4 @@
-const { promisify } = require('util');
+const { callbackify, promisify } = require('util');
 
 function libusb (device) {
   this.device = device;
@@ -27,8 +27,10 @@ libusb.prototype.close = function() {
   this.device.close();
 };
 
-libusb.prototype.setUpInterface = function (callback) {
-  if (!this.device.interfaces) { return callback(new Error('Failed to set up interface: device is not currently open.')); }
+libusb.prototype.setUpInterfaceAsync = async function () {
+  if (!this.device.interfaces) {
+    throw new Error('Failed to set up interface: device is not currently open.');
+  }
   var endpoints = this.device.interfaces[0].endpoints;
   function checkep(ep) { return ep.direction === this.toString(); }
 
@@ -36,16 +38,14 @@ libusb.prototype.setUpInterface = function (callback) {
   var epout = endpoints.filter(checkep, 'out');
 
   if (!epin.length || !epout.length) {
-    return callback(new Error('Failed to set up interface: could not find endpoint(s).'));
+    throw new Error('Failed to set up interface: could not find endpoint(s).');
   }
 
   this.conn.endpointOut = epout[0];
   this.conn.endpointIn = epin[0];
-
-  callback(null);
 };
 
-libusb.prototype.setUpInterfaceAsync = promisify(libusb.prototype.setUpInterface);
+libusb.prototype.setUpInterface = callbackify(libusb.prototype.setUpInterfaceAsync);
 
 libusb.prototype.write = function (buffer, callback) {
   this.conn.endpointOut.transfer(buffer, function (error) {

--- a/lib/serialport-comms.js
+++ b/lib/serialport-comms.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var c = require('./c');
+const { promisify } = require('util');
 
 function serialCom (port) {
   var self = this;
@@ -28,6 +29,8 @@ serialCom.prototype.setUpInterface = function(callback) {
   });
 };
 
+serialCom.prototype.setUpInterfaceAsync = promisify(serialCom.prototype.setUpInterface);
+
 serialCom.prototype.close = function() {
   this.responses = [];
   this.device.close();
@@ -46,11 +49,15 @@ serialCom.prototype.write = function(data, callback) {
   });
 };
 
+serialCom.prototype.writeAsync = promisify(serialCom.prototype.write);
+
 serialCom.prototype.read = function(length, callback) {
   //this.debug(this.responses);
   var packet = this.responses.splice(0, length);
   return callback(null, packet[0]);
 };
+
+serialCom.prototype.readAsync = promisify(serialCom.prototype.read);
 
 serialCom.prototype.sync = function(callback) {
   var self = this;

--- a/lib/serialport-comms.js
+++ b/lib/serialport-comms.js
@@ -37,15 +37,13 @@ serialCom.prototype.close = function() {
 };
 
 serialCom.prototype.write = function(data, callback) {
-  var self = this;
   // this will need to swap between 200 and 1000 depending on the command
   var drainDelay = 400;
 
-  this.device.write(data, function(error, results) {
+  this.device.write(data);
+  this.device.drain(function (error) {
     if (error) { return callback(new Error(error)); }
-    self.device.drain(function() {
-      setTimeout(callback, drainDelay);
-    });
+    setTimeout(callback, drainDelay);
   });
 };
 
@@ -84,11 +82,10 @@ serialCom.prototype.sync = function(callback) {
   }
 
   function trySync() {
-    self.device.write(signon, function(error, results) {
+    self.device.write(signon);
+    self.device.drain(function(error) {
       if (error) { return callback(new Error(error)); }
-      self.device.drain(function() {
-        setTimeout(check, 10);
-      });
+      setTimeout(check, 10);
     });
   };
 

--- a/lib/serialport-comms.js
+++ b/lib/serialport-comms.js
@@ -1,4 +1,3 @@
-var async = require('async');
 var c = require('./c');
 const { promisify } = require('util');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,6 @@
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/noopkat/avrgirl-stk500v2#readme",
   "dependencies": {
-    "async": "^1.4.0",
     "intel-hex": "^0.1.2"
   },
   "devDependencies": {

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -277,8 +277,8 @@ test('[ AVRGIRL-STK500V2 ] ::eraseChip', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::readMem', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
   var lMSB = 0x04 >> 8;
   var lLSB = 0x04;
   var buf1 = Buffer.from([0x14, lMSB, lLSB, 0x20]);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -185,7 +185,7 @@ test('[ AVRGIRL-STK500V2 ] ::verifySignature', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::loadAddress', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'sendCmd');
+  var spy = sinon.spy(a, 'sendCmdAsync');
   var dMSB1 = 0x80;
   var dMSB2 = 0x00;
   var msb1 = (0 >> 24) & 0xFF | dMSB1;

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -336,8 +336,8 @@ test('[ AVRGIRL-STK500V2 ] ::getParameter', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::readFuses', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
   var fuses = 3;
 
   t.plan(5);
@@ -353,8 +353,8 @@ test('[ AVRGIRL-STK500V2 ] ::readFuses', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::readFuse', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
 
   t.plan(6);
 

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -519,8 +519,8 @@ test('[ AVRGIRL-STK500V2 ] ::quickEeprom', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::getChipSignature', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
   var count = 3;
 
   t.plan(5);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -307,7 +307,7 @@ test('[ AVRGIRL-STK500V2 ] ::readMem', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::setParameter', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'sendCmd');
+  var spy = sinon.spy(a, 'sendCmdAsync');
   var buf = Buffer.from([0x02, 0x98, 0x01]);
 
   t.plan(2);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -264,7 +264,7 @@ test('[ AVRGIRL-STK500V2 ] ::exitProgrammingMode', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::eraseChip', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'sendCmd');
+  var spy = sinon.spy(a, 'sendCmdAsync');
   var buf = Buffer.from([0x12, 10, 0x01, 0xAC, 0x80, 0x00, 0x00]);
 
   t.plan(2);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -485,9 +485,9 @@ test('[ AVRGIRL-STK500V2 ] ::writeMem', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::quickFlash', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyEnter = sinon.spy(a, 'enterProgrammingMode');
-  var spyw = sinon.spy(a, 'writeFlash');
-  var spyExit = sinon.spy(a, 'exitProgrammingMode');
+  var spyEnter = sinon.spy(a, 'enterProgrammingModeAsync');
+  var spyw = sinon.spy(a, 'writeFlashAsync');
+  var spyExit = sinon.spy(a, 'exitProgrammingModeAsync');
   var file = __dirname + '/data/pr.hex';
 
   t.plan(4);
@@ -502,9 +502,9 @@ test('[ AVRGIRL-STK500V2 ] ::quickFlash', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::quickEeprom', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyEnter = sinon.spy(a, 'enterProgrammingMode');
-  var spyw = sinon.spy(a, 'writeEeprom');
-  var spyExit = sinon.spy(a, 'exitProgrammingMode');
+  var spyEnter = sinon.spy(a, 'enterProgrammingModeAsync');
+  var spyw = sinon.spy(a, 'writeEepromAsync');
+  var spyExit = sinon.spy(a, 'exitProgrammingModeAsync');
   var file = __dirname + '/data/eeprom.hex';
 
   t.plan(4);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -537,8 +537,8 @@ test('[ AVRGIRL-STK500V2 ] ::getChipSignature', function (t) {
 test('[ AVRGIRL-STK500V2 ] ::writeFuse', function (t) {
   var a = new avrgirl(FLoptions);
   var buf = Buffer.from([0x17, 0xAC, 0xA4, 0x00, 0xFF]);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
 
   t.plan(3);
 

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -320,8 +320,8 @@ test('[ AVRGIRL-STK500V2 ] ::setParameter', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::getParameter', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
   var buf = Buffer.from([0x03, 0x98]);
 
   t.plan(4);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -153,8 +153,8 @@ test('[ AVRGIRL-STK500V2 ] ::sendCmd', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::getSignature', function (t) {
   var a = new avrgirl(FLoptions);
-  var spyw = sinon.spy(a, 'write');
-  var spyr = sinon.spy(a, 'read');
+  var spyw = sinon.spy(a, 'writeAsync');
+  var spyr = sinon.spy(a, 'readAsync');
   var buf = Buffer.from([0x01]);
 
   t.plan(3);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -211,7 +211,7 @@ test('[ AVRGIRL-STK500V2 ] ::loadAddress', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::loadPage', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'sendCmd');
+  var spy = sinon.spy(a, 'sendCmdAsync');
   var lMSB = 5 >> 8;
   var lLSB = 5 & 0xFF;
   var data = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -429,7 +429,7 @@ test('[ AVRGIRL-STK500V2 ] ::writeEeprom', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::readEeprom', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'readMem');
+  var spy = sinon.spy(a, 'readMemAsync');
   var length = 20;
 
   t.plan(3);
@@ -443,7 +443,7 @@ test('[ AVRGIRL-STK500V2 ] ::readEeprom', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::readFlash', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'readMem');
+  var spy = sinon.spy(a, 'readMemAsync');
   var length = 20;
 
   t.plan(3);

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -374,7 +374,7 @@ test('[ AVRGIRL-STK500V2 ] ::readFuse', function (t) {
 // TODO: test for data length being too large, return error
 test('[ AVRGIRL-STK500V2 ] ::writeFlash', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'writeMem');
+  var spy = sinon.spy(a, 'writeMemAsync');
   var tinydata = Buffer.alloc(50);
   var largedata = Buffer.alloc(500);
   var file = __dirname + '/data/pr.hex';
@@ -402,7 +402,7 @@ test('[ AVRGIRL-STK500V2 ] ::writeFlash', function (t) {
 // TODO: test for data length being too large, return error
 test('[ AVRGIRL-STK500V2 ] ::writeEeprom', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'writeMem');
+  var spy = sinon.spy(a, 'writeMemAsync');
   var tinydata = Buffer.alloc(3);
   var largedata = Buffer.alloc(20);
   var file = __dirname + '/data/eeprom.hex';

--- a/tests/avrgirl-stk500v2.spec.js
+++ b/tests/avrgirl-stk500v2.spec.js
@@ -238,7 +238,7 @@ test('[ AVRGIRL-STK500V2 ] ::loadPage', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::enterProgrammingMode', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'sendCmd');
+  var spy = sinon.spy(a, 'sendCmdAsync');
   var buf = Buffer.from([0x10, 0xC8, 0x64, 0x19, 0x20, 0x00, 0x53, 0x03, 0xAC, 0x53, 0x00, 0x00]);
 
   t.plan(2);
@@ -251,7 +251,7 @@ test('[ AVRGIRL-STK500V2 ] ::enterProgrammingMode', function (t) {
 
 test('[ AVRGIRL-STK500V2 ] ::exitProgrammingMode', function (t) {
   var a = new avrgirl(FLoptions);
-  var spy = sinon.spy(a, 'sendCmd');
+  var spy = sinon.spy(a, 'sendCmdAsync');
   var buf = Buffer.from([0x11, 0x01, 0x01]);
 
   t.plan(2);

--- a/tests/helpers/mock-libusb-comms.js
+++ b/tests/helpers/mock-libusb-comms.js
@@ -1,3 +1,5 @@
+const { promisify } = require('util');
+
 function libusb (device) {
   this.device = device;
   this.conn = {};
@@ -11,9 +13,13 @@ libusb.prototype.setUpInterface = function (callback) {
   callback(null);
 };
 
+libusb.prototype.setUpInterfaceAsync = promisify(libusb.prototype.setUpInterface);
+
 libusb.prototype.write = function (buffer, callback) {
   callback(null);
 };
+
+libusb.prototype.writeAsync = promisify(libusb.prototype.write);
 
 libusb.prototype.read = function (length, callback) {
   var data = Buffer.alloc(length);
@@ -21,5 +27,7 @@ libusb.prototype.read = function (length, callback) {
   data[1] = 0x00;
   callback(null, data);
 };
+
+libusb.prototype.readAsync = promisify(libusb.prototype.read);
 
 module.exports = libusb;

--- a/tests/serialport-comms.spec.js
+++ b/tests/serialport-comms.spec.js
@@ -74,12 +74,14 @@ test('[ SERIALPORT-COMMS ] ::write', function (t) {
   var b = new serialcom(device);
   var buf = Buffer.from([0x01]);
 
-  t.plan(1);
+  t.plan(2);
 
   var spy = sinon.spy(device, 'write');
-  b.write(buf);
-  var cond = (spy.calledOnce && spy.args[0][0] && buf.equals(spy.args[0][0]));
-  t.ok(cond, 'called write method on correct endpoint with correct buffer arg');
+  b.write(buf, function(error) {
+    t.error(error, 'no error');
+    var cond = (spy.calledOnce && spy.args[0][0] && buf.equals(spy.args[0][0]));
+    t.ok(cond, 'called write method on correct endpoint with correct buffer arg');
+  });
 });
 
 test('[ SERIALPORT-COMMS ] ::read', function (t) {


### PR DESCRIPTION
Hi, Mattias here ([Calculator1992 on Twitch](https://www.twitch.tv/calculator1992))! 👋

I know you've been working on refactoring this library to `async`/`await` during your Sunday live streams, but getting a bit frustrated with the whole ordeal. There's only so much we can do to help through Twitch chat, so instead I thought I'd give the refactor a go myself. 😅

I know you said you want to do this refactor yourself, so you can get a deeper understanding about `async`/`await`. But perhaps you could use this pull request as a guideline, or steal some ideas from it. Or maybe you just close this pull request right away because you don't want to be influenced by other people's code, that's also totally fine by me. 😛

My approach:
1. Add an `*Async` variant for every existing method. Use [`util.promisify()`](https://nodejs.org/api/util.html#util_util_promisify_original) to turn the existing callback-accepting method into a promise-returning method.
1. One by one, rewrite every callback-accepting method to an `async function`. Use [`util.callbackify()`](https://nodejs.org/api/util.html#util_util_callbackify_original) to turn the (new) `async function` into a callback-accepting method, so the old method remains functional. This ensures that the tests keep passing *after every change*.

(I did not refactor the *tests* to use `async`/`await`. That's for another time. 😁)