### PR TITLE
Fix EEProm read not returning all data

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Returns a null error and a buffer of the read bytes upon callback if successful.
 Usage:
 
 ```javascript
-stk.readFlash(64, function(error, data) {
+stk.readEeprom(64, function(error, data) {
   console.log(error, data);
 });
 ```

--- a/lib/serialport-comms.js
+++ b/lib/serialport-comms.js
@@ -49,7 +49,11 @@ serialCom.prototype.write = function(data, callback) {
 serialCom.prototype.read = function(length, callback) {
   //this.debug(this.responses);
   var packet = this.responses.splice(0, length);
-  return callback(null, packet[0]);
+  var data = [];
+  packet.forEach(resp => {
+    data = data.concat(...resp);
+  });
+  return callback(null, data);
 };
 
 serialCom.prototype.sync = function(callback) {


### PR DESCRIPTION
The serial read was only returning the first 32 bytes of the requested data, I have fixed it to return the full set of data.

Also I have fixed a minor documentation error.