### PR TITLE
Serial Port Comms refactor

### DIFF
--- a/avrgirl-stk500v2.js
+++ b/avrgirl-stk500v2.js
@@ -22,7 +22,7 @@ function avrgirlStk500v2(options) {
   if (this.options.comm.path) {
     this.debug('serialport!');
     this.commType = 'serialcom';
-    this.device = new serialcom(this.options.comm);
+    this.device = serialcom(this.options.comm);
   } else {
     this.debug('libusb!');
     this.commType = 'libusb';

--- a/lib/serialport-comms.js
+++ b/lib/serialport-comms.js
@@ -1,91 +1,93 @@
 var async = require('async');
 var c = require('./c');
 
-function serialCom (port) {
-  var self = this;
-  this.device = port;
-  this.responses = [];
-  var devMode = true;
-  this.debug = devMode ? console.log : function() {};
+const serialCom = port => {
+  let responses = []
+  let devMode = true
+  const debug = devMode ? console.log : function() {}
 
-};
+  const open = () => port.open()
 
-serialCom.prototype.open = function() {
-  this.device.open();
-};
-
-serialCom.prototype.setUpInterface = function(callback) {
-  var self = this;
-  this.device.open(function() {
-    self.device.on('data', function(data) {
-      self.debug('data', data);
-      self.responses.push(data);
-    });
-    self.sync(function(error) {
-      self.debug('sync success', error);
-      return callback(error);
-    });
-  });
-};
-
-serialCom.prototype.close = function() {
-  this.responses = [];
-  this.device.close();
-};
-
-serialCom.prototype.write = function(data, callback) {
-  var self = this;
-  // this will need to swap between 200 and 1000 depending on the command
-  var drainDelay = 400;
-
-  this.device.write(data, function(error, results) {
-    if (error) { return callback(new Error(error)); }
-    self.device.drain(function() {
-      setTimeout(callback, drainDelay);
-    });
-  });
-};
-
-serialCom.prototype.read = function(length, callback) {
-  //this.debug(this.responses);
-  var packet = this.responses.splice(0, length);
-  return callback(null, packet[0]);
-};
-
-serialCom.prototype.sync = function(callback) {
-  var self = this;
-  var attempts = 0;
-  var signon = Buffer.from(c.SEQ_SIGN_ON);
-  var drainDelay = 1000;
-
-  function check() {
-    self.read(17, function(error, data) {
-      attempts += 1;
-      if (!data) {
-        if (attempts < 10) {
-          self.debug("trying again")
-          trySync();
-        } else {
-          self.debug('failure')
-          callback(new Error('attempt to sync with programmer failed.'));
-        }
-      } else {
-        self.debug('success');
-        callback(null, data);
-      }
+  const setUpInterface = callback => {
+    port.open(function() {
+      port.on('data', function(data) {
+        debug('data', data);
+        responses.push(data);
+      });
+      sync(function(error) {
+        debug('sync success', error);
+        return callback(error);
+      });
     });
   }
 
-  function trySync() {
-    self.device.write(signon, function(error, results) {
+  const close = () => {
+    responses = [];
+    port.close();
+  }
+
+  const write = (data, callback) => {
+    // this will need to swap between 200 and 1000 depending on the command
+    var drainDelay = 400;
+    port.write(data, function(error, results) {
       if (error) { return callback(new Error(error)); }
-      self.device.drain(function() {
-        setTimeout(check, 10);
+      port.drain(function() {
+        setTimeout(callback, drainDelay);
       });
     });
-  };
+  }
 
-  trySync();
-};
+  const read = (length, callback) => {
+    var packet = responses.splice(0, length);
+    return callback(null, packet[0]);
+  }
+
+  const sync = callback => {
+    var attempts = 0;
+    var signon = Buffer.from(c.SEQ_SIGN_ON);
+    var drainDelay = 1000;
+  
+    function check() {
+      read(17, function(error, data) {
+        attempts += 1;
+        if (!data) {
+          if (attempts < 10) {
+            debug("trying again")
+            trySync();
+          } else {
+            debug('failure')
+            callback(new Error('attempt to sync with programmer failed.'));
+          }
+        } else {
+          debug('success');
+          callback(null, data);
+        }
+      });
+    }
+  
+    function trySync() {
+      port.write(signon, function(error, results) {
+        if (error) { return callback(new Error(error)); }
+        port.drain(function() {
+          setTimeout(check, 10);
+        });
+      });
+    };
+  
+    trySync();
+  }
+
+  const protoSerialC = {
+    setUpInterface,
+    open,
+    close,
+    write,
+    read,
+    sync,
+    responses,
+  }
+
+  return Object.create(protoSerialC)
+}
 
 module.exports = serialCom;

--- a/tests/serialport-comms.spec.js
+++ b/tests/serialport-comms.spec.js
@@ -32,7 +32,7 @@ device.drain = function(callback) {
 };
 
 test('[ SERIALPORT-COMMS ] method presence', function (t) {
-  var b = new serialcom(device);
+  var b = serialcom(device);
   function isFn(name) {
     return typeof b[name] === 'function';
   };
@@ -52,7 +52,7 @@ test('[ SERIALPORT-COMMS ] method presence', function (t) {
 });
 
 test('[ SERIALPORT-COMMS ] ::open', function (t) {
-  var b = new serialcom(device);
+  var b = serialcom(device);
 
   var spy = sinon.spy(device, 'open');
 
@@ -62,7 +62,7 @@ test('[ SERIALPORT-COMMS ] ::open', function (t) {
 });
 
 test('[ SERIALPORT-COMMS ] ::close', function (t) {
-  var b = new serialcom(device);
+  var b = serialcom(device);
   var spy = sinon.spy(device, 'close');
 
   t.plan(1);
@@ -71,7 +71,7 @@ test('[ SERIALPORT-COMMS ] ::close', function (t) {
 });
 
 test('[ SERIALPORT-COMMS ] ::write', function (t) {
-  var b = new serialcom(device);
+  var b = serialcom(device);
   var buf = Buffer.from([0x01]);
 
   t.plan(1);
@@ -83,7 +83,7 @@ test('[ SERIALPORT-COMMS ] ::write', function (t) {
 });
 
 test('[ SERIALPORT-COMMS ] ::read', function (t) {
-  var b = new serialcom(device);
+  var b = serialcom(device);
   b.responses.push(Buffer.alloc(8));
   var spy = sinon.spy(b, 'read');
   t.plan(3);
@@ -96,7 +96,7 @@ test('[ SERIALPORT-COMMS ] ::read', function (t) {
 });
 
 test('[ SERIALPORT-COMMS ] ::setUpInterface', function (t) {
-  var b = new serialcom(device);
+  var b = serialcom(device);
   var stub = sinon.stub(b, 'sync', function(callback) {
     return callback(null);
   });


### PR DESCRIPTION
Hello Suz,

I tried to refactor serialport-comms.js to use factory functions.

Even though your code's size is small, the intention is to promote best practices through the use of this pattern.

More details about the benefits and drawbacks of this pattern are at:
https://medium.com/javascript-scene/javascript-factory-functions-vs-constructor-functions-vs-classes-2f22ceddf33e

One of the test failed to pass:

https://github.com/noopkat/avrgirl-stk500v2/blob/94ceefe20474238ce04be47d40de74d4a183cdde/tests/serialport-comms.spec.js#L98

I don't see what's the logic of using "this" and "self" on the calls to: this.device.open and self.device.on

https://github.com/noopkat/avrgirl-stk500v2/blob/94ceefe20474238ce04be47d40de74d4a183cdde/lib/serialport-comms.js#L18

https://github.com/noopkat/avrgirl-stk500v2/blob/94ceefe20474238ce04be47d40de74d4a183cdde/lib/serialport-comms.js#L19

https://github.com/noopkat/avrgirl-stk500v2/blob/94ceefe20474238ce04be47d40de74d4a183cdde/lib/serialport-comms.js#L20

Could you please tell me more details about how the setUpInterface function works ?

https://github.com/noopkat/avrgirl-stk500v2/blob/94ceefe20474238ce04be47d40de74d4a183cdde/lib/serialport-comms.js#L17

I got this output on the console:

```
[ SERIALPORT-COMMS ] ::setUpInterface

    ✖ plan != count
    ----------------
      operator: fail
      expected: 3
      actual:   0
      at: process.<anonymous> (/javascript_projects/avrgirl-stk500v2/node_modules/tape/index.js:83:19)
      stack: |-

  Failed Tests: There was 1 failure

    [ SERIALPORT-COMMS ] ::setUpInterface

      ✖ plan != count

  total:     158
  passing:   157
  failing:   1
  duration:  177ms
```

Do you have any idea about why this happens?

Thanks in advance : )
